### PR TITLE
Fix the broken link in getting-started page to open an issue.

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -432,7 +432,7 @@ chromeDriver: ''
     <div class="page-header">
       <h1 id="troubleshooting">Troubleshooting</h1>
     </div>
-    <p class="lead">We will document any "gotchas" here along with any important open GitHub issues. Please <a href="https://github.com/CleverStack/cleverstack/issues">open an issue</a> if you see a bug.</p></p>
+    <p class="lead">We will document any "gotchas" here along with any important open GitHub issues. Please <a href="https://github.com/clevertech/cleverstack/issues">open an issue</a> if you see a bug.</p></p>
   </div>
 
   <!-- FAQ


### PR DESCRIPTION
I fixed the broken link in the Getting started page ("https://github.com/CleverStack/cleverstack.io.git").  Before, under the trouble shooting section, the link would turn up an error message.  Now, it goes to the correct page.
Thank you!
