### PR TITLE
Added links to the clever-stack Google Group.

### DIFF
--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -206,6 +206,7 @@ $ bower search cleverstack-module
     <ul>
       <li>Check the Github <a href="https://github.com/cleverstack/cleverstack-cli/issues">issues page</a>.</li>
       <li>Log into the public access <a href="https://www.hipchat.com/gwM43u4Mw">HipChat Room</a> and ask for help.</li>
+      <li>Get some help from the Cleverstack <a href="https://groups.google.com/forum/#!forum/clever-stack">Google Group</a></li>
       <li>If your still having problems, please <a href="https://github.com/CleverStack/cleverstack-cli/issues/new">raise an issue</a>.</li>
     </ul>
 
@@ -1049,6 +1050,7 @@ Starting server on port 8080 in LOCAL mode
 
       <li>Check the Github <a href="https://github.com/CleverStack/Node-Seed/issues">issues page</a>.</li>
       <li>Log into the public access <a href="https://www.hipchat.com/gwM43u4Mw">HipChat Room</a> and ask for help.</li>
+      <li>Get some help from the Cleverstack <a href="https://groups.google.com/forum/#!forum/clever-stack">Google Group</a></li>
       <li>If your still having problems, please <a href="https://github.com/CleverStack/Node-Seed/issues/new">raise an issue</a>.</li>
     </ul>
 
@@ -1250,6 +1252,7 @@ example-module/
     <ul>
       <li>Check the Github <a href="https://github.com/CleverStack/Angular-Seed/issues">issues page</a>.</li>
       <li>Log into the public access <a href="https://www.hipchat.com/gwM43u4Mw">HipChat Room</a> and ask for help.</li>
+      <li>Get some help from the Cleverstack <a href="https://groups.google.com/forum/#!forum/clever-stack">Google Group</a></li>
       <li>If your still having problems, please <a href="https://github.com/CleverStack/Angular-Seed/issues/new">raise an issue</a>.</li>
     </ul>
 
@@ -1341,6 +1344,7 @@ chromeDriver: ''
     <h4><a href="#cli-troubleshooting">Troubleshooting CleverStack CLI.</a></h4>
     <h4><a href="#backend-troubleshooting">Troubleshooting Backend (NodeJS).</a></h4>
     <h4><a href="#frontend-troubleshooting">Troubleshooting Frontend (AngularJS).</a></h4><br>
+    <h4><a href="https://groups.google.com/forum/#!forum/clever-stack">Get some help from the Google Group</a></h4><br>
 
     <p class="lead">We will document any "gotchas" here along with any important open GitHub issues. Please <a href="https://github.com/CleverStack/cleverstack/issues">open an issue</a> if you see a bug.</p></p>
     <ul>


### PR DESCRIPTION
This is my first ever github pull request.  I hope I'm doing this right.

I have added links to the new 'clever-stack' Google Group on the main documentation page.

I think the best way to handle user communication needs is for a discussion to begin in the Google Group.  If it's just a matter of someone needing instructions, then it can end there.  If there's a bona fide bug, then someone can make a github issue out of it in the appropriate repository and include a link to the Google Group thread in the issue.

Rationale:
1. Discussions are permanent.  Chatroom conversations are not.
2. Google Group discussions are easier to find with a search engine than github issue discussions.
3. There will be only one Google Group for all of Cleverstack even though there are multiple Cleverstack repositories.  This means people will only need to look in one place to find answers to all Cleverstack questions and not have to decide, possibly badly, which repository is the best place to put their question.
4.  People are not used to the idea of using github issues for questions and discussions.  I have many times been reprimanded for doing that and had my question abruptly "closed"
5. Questions as github issues require one of the [contributors to label](http://stackoverflow.com/questions/13829466/how-to-put-a-label-on-an-issue-in-github) them as such.  This is extra work and something that can possibly be forgotten to do.
6.  Users can easily control their subscription to the Google Group to get as many notifications as they want
